### PR TITLE
tds_netimpl_arduino: support partial pulls

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,6 +1,5 @@
 name: CI
 on:
-  push:
   pull_request:
     branches: [main]
 
@@ -115,11 +114,12 @@ jobs:
           pio pkg pack -o tdslite.tar.gz
           pio lib --global install ./tdslite.tar.gz
           pio lib --global install arduino-libraries/Ethernet
+          pio lib --global install arduino-libraries/WiFiNINA
           pio lib --global install ./extras/vendor/MemoryFree
       - name: build-avr
         run: pio ci --project-option="lib_ignore=CrashMonitor" --board nanoatmega328 --board uno --board megaatmega1280 --board megaatmega2560 --board miniatmega328 --board micro --board yun --board nanoatmega328new --board pro8MHzatmega328 --board ethernet tests/sketches/arduino/arduino.cpp
       - name: build-esp
-        run: pio ci --project-option="lib_ignore=CrashMonitor" --board nodemcu-32s --board nodemcuv2 tests/sketches/esp/esp.cpp
+        run: pio ci --project-option="lib_ignore=WiFiNINA" --board nodemcu-32s --board nodemcuv2 tests/sketches/esp/esp.cpp
       - name: build-rpi
         run: pio ci --project-option="lib_ignore=CrashMonitor" --board nanorp2040connect tests/sketches/arduino/arduino.cpp
       - name: build-nrf
@@ -128,7 +128,32 @@ jobs:
         run: pio ci --project-option="lib_ignore=CrashMonitor" --board portenta_h7_m4 --board uno --board portenta_h7_m7 tests/sketches/arduino/arduino.cpp
       - name: build-samd
         run: pio ci --project-option="lib_ignore=CrashMonitor" --board zero tests/sketches/arduino/arduino.cpp
-
+      - name: build-arduino-uno-wifi-r2
+        run: pio ci --project-option="lib_ignore=CrashMonitor" --board uno_wifi_rev2 tests/sketches/esp/esp.cpp
+  Build-Examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+      - name: Install PlatformIO libraries
+        run: |
+          pio pkg pack -o tdslite.tar.gz
+          pio lib --global install ./tdslite.tar.gz
+          pio lib --global install arduino-libraries/Ethernet
+          pio lib --global install ./extras/vendor/MemoryFree
+          pio lib --global install arduino-libraries/WiFiNINA
+      - name: board-example-uno-wifi-r2
+        run: pio ci --project-option="lib_ignore=CrashMonitor" --board uno_wifi_rev2 examples/boards/uno_wifi_r2/uno_wifi_r2.ino
   Arduino-Library-Lint:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ It's a playground to try sql commands. Compile the project, and just run `./buil
 
 Verificaton sketches for the library
 
+[➤ Board-specific examples](https://github.com/mustafakemalgilor/tdslite/tree/main/examples/boards)
+
+- [Arduino Uno WiFi rev.2](https://github.com/mustafakemalgilor/tdslite/tree/main/examples/boards/uno_wifi_r2/uno_wifi_r2.ino): Uses WiFiNINA & tdslite to perform INSERT & SELECT.
+
 ----
 
 ## Key features

--- a/examples/boards/uno_wifi_r2/uno_wifi_r2.ino
+++ b/examples/boards/uno_wifi_r2/uno_wifi_r2.ino
@@ -1,0 +1,271 @@
+/**
+ * ____________________________________________________
+ * Board-specific tdslite example for Arduino Uno WiFi
+ - R2.
+ *
+ * @file   uno_wifi_r2.ino
+ * @author mkg <hello@mkg.dev>
+ * @date   14.07.2023
+ *
+ * SPDX-License-Identifier:    MIT
+ * ____________________________________________________
+ */
+
+#if !defined(ARDUINO_AVR_UNO_WIFI_REV2)
+#warning "Current board is not Arduino Uno WiFi R2."
+#endif
+
+#include <WiFiNINA.h>
+
+// --------------------------------------------------------------------------------
+// Sketch options
+// --------------------------------------------------------------------------------
+
+#define SKETCH_ENABLE_SERIAL_OUTPUT                // comment out this to disable serial output
+#define SKETCH_TDSL_NETBUF_SIZE     512 * 4        // tdslite network buffer size
+#define SKETCH_TDSL_PACKET_SIZE     1400           // tds PDU size
+#define SKETCH_WIFI_SSID            "<>"           // put your SSID (i.e. wifi name) here
+#define SKETCH_WIFI_PASSWORD        "<>"           // wifi password
+#define SKETCH_DB_IP_OR_HOSTNAME    "192.168.1.27" // database server IP
+#define SKETCH_DB_NAME              "master"       // database to connect
+#define SKETCH_DB_PORT              14333          // port number (default is 1433!)
+#define SKETCH_DB_USERNAME          "sa"           // database user
+#define SKETCH_DB_PASSWORD          "2022-tds-lite-test!" // database user's password
+
+// --------------------------------------------------------------------------------
+// Serial output
+// --------------------------------------------------------------------------------
+
+#ifdef SKETCH_ENABLE_SERIAL_OUTPUT
+
+#define SERIAL_PRINTF(FMTSTR, ...)                                                                 \
+    [&]() {                                                                                        \
+        static_assert(sizeof(FMTSTR) <= 255, "Format string cannot be greater than 255");          \
+        /* Save format string into program */                                                      \
+        /* memory to save flash space */                                                           \
+        static const char __fmtpm [] PROGMEM = FMTSTR;                                             \
+        char buf [128]                       = {};                                                 \
+        snprintf_P(buf, sizeof(buf), __fmtpm, ##__VA_ARGS__);                                      \
+        Serial.print(buf);                                                                         \
+    }()
+
+#define SERIAL_PRINTLNF(FMTSTR, ...)                                                               \
+    SERIAL_PRINTF(FMTSTR, ##__VA_ARGS__);                                                          \
+    Serial.println("")
+
+#define SERIAL_PRINT_U16_AS_MB(U16SPAN)                                                            \
+    [](tdsl::u16char_view v) {                                                                     \
+        for (const auto ch : v) {                                                                  \
+            Serial.print(static_cast<char>(ch));                                                   \
+        }                                                                                          \
+    }(U16SPAN)
+
+#else
+#define SERIAL_PRINTF(FMTSTR, ...)
+#define SERIAL_PRINTLNF(FMTSTR, ...)
+#define SERIAL_PRINT_U16_AS_MB(U16SPAN)
+#endif
+
+#define TDSL_DEBUG_PRINT(FMTSTR, ...)       SERIAL_PRINTF(FMTSTR, ##__VA_ARGS__)
+#define TDSL_DEBUG_PRINTLN(FMTSTR, ...)     SERIAL_PRINTLNF(FMTSTR, ##__VA_ARGS__)
+#define TDSL_DEBUG_PRINT_U16_AS_MB(U16SPAN) SERIAL_PRINT_U16_AS_MB(U16SPAN)
+
+#include <tdslite.h>
+
+inline bool init_serial() {
+#ifdef SKETCH_ENABLE_SERIAL_OUTPUT
+    Serial.begin(115200);
+    while (!Serial)
+        ;
+#endif
+    return true;
+}
+
+// --------------------------------------------------------------------------------
+// WiFi
+// --------------------------------------------------------------------------------
+
+inline void scan_aps() {
+    SERIAL_PRINTLNF("... scanning networks ...");
+    const auto ssid_count = WiFi.scanNetworks();
+    if (ssid_count == -1) {
+        SERIAL_PRINTLNF("... cannot get a WiFi connection! ...");
+        return;
+    }
+    SERIAL_PRINTLNF("... found %d network(s) ...", ssid_count);
+    for (auto i = 0; i < ssid_count; i++) {
+        SERIAL_PRINTLNF("... [%d]: %s (%ld dBm, encryption %d) ...", i, WiFi.SSID(i), WiFi.RSSI(i),
+                        WiFi.encryptionType(i));
+    }
+}
+
+// --------------------------------------------------------------------------------
+
+inline bool wifi_setup() {
+    SERIAL_PRINTLNF("... wifi setup ...");
+
+    const char ssid []     = SKETCH_WIFI_SSID;
+    const char password [] = SKETCH_WIFI_PASSWORD;
+    // WiFi.mode(WIFI_STA); // Optional
+    int status             = WL_IDLE_STATUS; // the WiFi radio's status
+
+    if (WiFi.status() == WL_NO_MODULE) {
+        Serial.println("Communication with WiFi module failed!");
+        // don't continue
+        while (true)
+            ;
+    }
+    String fv = WiFi.firmwareVersion();
+    if (fv < WIFI_FIRMWARE_LATEST_VERSION) {
+        Serial.println("Please upgrade the firmware");
+    }
+
+    scan_aps();
+
+    while (not(status == WL_CONNECTED)) {
+        status = WiFi.begin(ssid, password);
+        SERIAL_PRINTLNF("... waiting for WiFi connection ...");
+        Serial.print(status);
+        delay(15000);
+    };
+    SERIAL_PRINTLNF("Connected to the WiFi network `%s`, IP address is: %d.%d.%d.%d", ssid,
+                    WiFi.localIP() [0], WiFi.localIP() [1], WiFi.localIP() [2], WiFi.localIP() [3]);
+    return true;
+}
+
+// --------------------------------------------------------------------------------
+// user callbacks
+// --------------------------------------------------------------------------------
+
+/**
+ * Prints INFO/ERROR messages from SQL server to stdout.
+ *
+ * @param [in] token INFO/ERROR token
+ */
+static void info_callback(void *, const tdsl::tds_info_token & token) noexcept {
+    SERIAL_PRINTF("%c: [%d/%d/%d@%d] --> ", (token.is_info() ? 'I' : 'E'), token.number,
+                  token.state, token.class_, token.line_number);
+    SERIAL_PRINT_U16_AS_MB(token.msgtext);
+    SERIAL_PRINTLNF("");
+}
+
+// --------------------------------------------------------------------------------
+
+/**
+ * Handle row data coming from tdsl driver
+ *
+ * @param [in] u user pointer (table_context)
+ * @param [in] colmd Column metadata
+ * @param [in] row Row information
+ */
+static void row_callback(void * u, const tdsl::tds_colmetadata_token & colmd,
+                         const tdsl::tdsl_row & row) {
+    (void) u;
+    (void) colmd;
+
+    SERIAL_PRINTF("row: ");
+    for (const auto & field : row) {
+        SERIAL_PRINTF("%d\t", field.as<tdsl::uint32_t>());
+    }
+    SERIAL_PRINTLNF("");
+}
+
+// --------------------------------------------------------------------------------
+// tdslite
+
+// The network buffer
+tdsl::uint8_t net_buf [SKETCH_TDSL_NETBUF_SIZE] = {};
+tdsl::arduino_driver<WiFiClient> driver{net_buf};
+
+// --------------------------------------------------------------------------------
+
+void tdslite_database_init() noexcept {
+    SERIAL_PRINTLNF("... init database begin...");
+    const auto r = driver.execute_query("CREATE TABLE #hello_world(a int, b int, c varchar(255));");
+    (void) r;
+    SERIAL_PRINTLNF("... init database end, result `%d`...", r);
+}
+
+// --------------------------------------------------------------------------------
+
+bool tdslite_setup() noexcept {
+    SERIAL_PRINTLNF("... init tdslite ...");
+    decltype(driver)::connection_parameters params;
+    // Server's hostname or IP address.
+    params.server_name = SKETCH_DB_IP_OR_HOSTNAME; // WL
+    //  SQL server port number
+    params.port        = SKETCH_DB_PORT;
+    // Login user
+    params.user_name   = SKETCH_DB_USERNAME;
+    // Login user password
+    params.password    = SKETCH_DB_PASSWORD;
+    // Client name(optional)
+    params.client_name = "arduino uno test sketch";
+    // App name(optional)
+    params.app_name    = "sketch";
+    // Database name(optional)
+    params.db_name     = SKETCH_DB_NAME;
+    // TDS packet size
+    // Recommendation: Half of the network buffer.
+    params.packet_size = {SKETCH_TDSL_PACKET_SIZE};
+    driver.set_info_callback(&info_callback, nullptr);
+    auto cr = driver.connect(params);
+    if (not(decltype(driver)::e_driver_error_code::success == cr)) {
+        SERIAL_PRINTLNF("... tdslite init failed, connection failed %d ...",
+                        static_cast<tdsl::uint32_t>(cr));
+        return false;
+    }
+
+    tdslite_database_init();
+    SERIAL_PRINTLNF("... init tdslite end...");
+    return true;
+}
+
+// --------------------------------------------------------------------------------
+
+inline void tdslite_loop() noexcept {
+    static int i = 0;
+    driver.execute_query(
+        "INSERT INTO #hello_world VALUES(1,2, "
+        "'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor "
+        "incididunt ut labore et dolore magna aliqua. Semper viverra nam libero justo laoreet sit "
+        "amet. Fringilla ut morbi tincidunt augue interdum velit.')");
+    if (i++ % 10 == 0) {
+        const auto result = driver.execute_query("SELECT * FROM #hello_world;", row_callback);
+        SERIAL_PRINTLNF(">> Report: row count [%d] <<", result.affected_rows);
+    }
+}
+
+// --------------------------------------------------------------------------------
+// main sketch routines
+// --------------------------------------------------------------------------------
+
+inline void rgb_led_set_color(int r, int g, int b) noexcept {
+    WiFiDrv::analogWrite(25, r);
+    WiFiDrv::analogWrite(26, g);
+    WiFiDrv::analogWrite(27, b);
+}
+
+void setup() {
+    bool r = {false};
+    r      = init_serial();
+    r      = r && wifi_setup();
+    r      = r && tdslite_setup();
+    if (not r) {
+        SERIAL_PRINTLNF("... setup failed ...");
+        for (;;) {
+            delay(1000);
+        }
+    }
+    SERIAL_PRINTLNF("--- setup finished ---");
+}
+
+// --------------------------------------------------------------------------------
+
+void loop() {
+    tdslite_loop();
+    // set onboard RGB led to a random color
+    // in order to indicate activity
+    rgb_led_set_color(random(0, 255), random(0, 255), random(0, 255));
+    delay(250);
+}

--- a/extras/docs/notes.md
+++ b/extras/docs/notes.md
@@ -10,9 +10,9 @@
 - Network implementation MUST read negotiated packet size and send packets accordingly -- [DONE]
 - Use platform-specific size_t & ssize_t instead of using int64_t's for space [DONE]
 - Implement an arduino program memory string view type [DONE]
-- Beautify README.md
-- Publish to GitHub Releases, Arduino Libraries and PlatformIO Libraries
-- add badges for arduino, platform.io, snap and ci pipeline status
+- Beautify README.md [~DONE]
+- Publish to GitHub Releases [DONE], Arduino Libraries [DONE] and PlatformIO Libraries [DONE]
+- add badges for arduino [DONE], platform.io [DONE], snap and ci pipeline status [DONE]
 
 ----
 
@@ -34,3 +34,5 @@
   ```
 
   - For all boards with ESP MCU's : `pio boards --json-output | jq -c '.[] | select(.mcu|contains("ESP")) | .id' | xargs printf -- '--board\0%s\0' | tr '\n' '\0' | xargs -0 pio ci examples/esp/esp.cpp`
+
+  - To find which macro is defined for a specific arduino board: [boards.txt](https://github.com/arduino/ArduinoCore-megaavr/blob/5e639ee40afa693354d3d056ba7fb795a8948c11/boards.txt#L25) (see build.board field of each respective board)

--- a/extras/prep-lib.sh
+++ b/extras/prep-lib.sh
@@ -12,10 +12,13 @@ SCRIPT_ROOT="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 PROJECT_ROOT=$SCRIPT_ROOT/..
 BUILD_FOLDER=$PROJECT_ROOT/build
 PACK_TMP=$BUILD_FOLDER/arduino-libpack-root/tdslite
-rm $PACK_TMP &> /dev/null || true
+rm -rf $BUILD_FOLDER/arduino-libpack-root &> /dev/null || true
 mkdir -p $PACK_TMP
 cd $PROJECT_ROOT
 pio pkg pack -o $PACK_TMP/tdslite.tar.gz
 cd $PACK_TMP
-tar xzf tdslite.tar.gz && zip -q tdslite.zip $(tar tf tdslite.tar.gz)
+tar xzf tdslite.tar.gz
+mv tdslite.tar.gz $BUILD_FOLDER/arduino-libpack-root
+cd $BUILD_FOLDER/arduino-libpack-root
+zip -q -r tdslite.zip tdslite/
 ls -lrah tdslite.zip

--- a/extras/test-avr-boards.sh
+++ b/extras/test-avr-boards.sh
@@ -3,11 +3,11 @@
 pio lib --global uninstall tdslite
 pio lib --global uninstall CrashMonitor
 pio lib --global uninstall MemoryFree
+pio lib --global uninstall arduino-libraries/WiFiNINA
 
 pio pkg pack -o build/tdslite.tar.gz
 pio lib --global install ./build/tdslite.tar.gz
 pio lib --global install arduino-libraries/Ethernet@2.0.1
-pio lib --global install ./build/arduino-libpack-root/tdslite.zip
 pio lib --global install ./extras/vendor/MemoryFree
 
 set -eu
@@ -36,14 +36,12 @@ PLATFORMIO_BUILD_FLAGS=-DCI_BUILD pio ci \
 tests/sketches/arduino/arduino.cpp
 
 # Test Arduino RPi boards
-
 PLATFORMIO_BUILD_FLAGS=-DCI_BUILD pio ci \
 --project-option="lib_ignore=CrashMonitor" \
 --board nanorp2040connect \
 tests/sketches/arduino/arduino.cpp
 
 # Test Arduino STM boards
-
 PLATFORMIO_BUILD_FLAGS=-DCI_BUILD pio ci \
 --project-option="lib_ignore=CrashMonitor" \
 --board portenta_h7_m4 \
@@ -51,7 +49,6 @@ PLATFORMIO_BUILD_FLAGS=-DCI_BUILD pio ci \
 tests/sketches/arduino/arduino.cpp
 
 # Test Arduino nRF boards
-
 PLATFORMIO_BUILD_FLAGS=-DCI_BUILD pio ci \
 --project-option="lib_ignore=CrashMonitor" \
 --board nano33ble \
@@ -59,11 +56,18 @@ PLATFORMIO_BUILD_FLAGS=-DCI_BUILD pio ci \
 tests/sketches/arduino/arduino.cpp
 
 # Test ESP based boards
-
 PLATFORMIO_BUILD_FLAGS=-DCI_BUILD pio ci \
---project-option="lib_ignore=CrashMonitor" \
+--project-option="lib_ignore=WiFiNINA" \
 --board nodemcu-32s \
 --board nodemcuv2 \
+tests/sketches/esp/esp.cpp
+
+pio lib --global install arduino-libraries/WiFiNINA
+
+# Test Arduino WiFi boards
+PLATFORMIO_BUILD_FLAGS=-DCI_BUILD pio ci \
+--project-option="lib_ignore=CrashMonitor" \
+--board uno_wifi_rev2 \
 tests/sketches/esp/esp.cpp
 
 

--- a/src/tdslite-net/arduino/tdsl_netimpl_arduino.hpp
+++ b/src/tdslite-net/arduino/tdsl_netimpl_arduino.hpp
@@ -269,7 +269,7 @@ namespace tdsl { namespace net {
 
             if (transfer_exactly > rem_space) {
                 TDSL_DEBUG_PRINTLN("tdsl_netimpl_arduino::do_recv(...) -> error, not enough "
-                                   "space in recv buffer (%u vs %zu)",
+                                   "space in recv buffer (%u vs " TDSL_SIZET_FORMAT_SPECIFIER ")",
                                    transfer_exactly, rem_space);
                 TDSL_ASSERT(0);
                 return network_io_result::unexpected(-2);

--- a/src/tdslite-net/arduino/tdsl_netimpl_arduino.hpp
+++ b/src/tdslite-net/arduino/tdsl_netimpl_arduino.hpp
@@ -217,14 +217,6 @@ namespace tdsl { namespace net {
                         "tdsl_netimpl_arduino::do_recv(...) -> read amount: %u, demanded:%u",
                         read_amount, amount_demanded);
 
-                    if (read_amount > amount_demanded) {
-                        TDSL_ASSERT(false);
-                        // This cannot happen in a normal implementation
-                        // i.e. the client's read() function is buggy.
-                        return network_io_result::unexpected(
-                            static_cast<int>(errc::unexpected_read_amount));
-                    }
-
                     if (read_amount == 0) {
                         TDSL_DEBUG_PRINTLN(
                             "tdsl_netimpl_arduino::do_recv(...) -> ret 0, disconnected");
@@ -240,6 +232,13 @@ namespace tdsl { namespace net {
                         delay(poll_interval);
                     }
                     else {
+                        if (static_cast<tdsl::uint32_t>(read_amount) > amount_demanded) {
+                            TDSL_ASSERT(false);
+                            // This cannot happen in a normal implementation
+                            // i.e. the client's read() function is buggy.
+                            return network_io_result::unexpected(
+                                static_cast<int>(errc::unexpected_read_amount));
+                        }
                         TDSL_ASSERT((bytes_recvd + read_amount) <= transfer_exactly);
                         // Data received
                         bytes_recvd += read_amount;
@@ -270,7 +269,7 @@ namespace tdsl { namespace net {
 
             if (transfer_exactly > rem_space) {
                 TDSL_DEBUG_PRINTLN("tdsl_netimpl_arduino::do_recv(...) -> error, not enough "
-                                   "space in recv buffer (%u vs %ld)",
+                                   "space in recv buffer (%u vs %zu)",
                                    transfer_exactly, rem_space);
                 TDSL_ASSERT(0);
                 return network_io_result::unexpected(-2);

--- a/src/tdslite-net/arduino/tdsl_netimpl_arduino.hpp
+++ b/src/tdslite-net/arduino/tdsl_netimpl_arduino.hpp
@@ -213,7 +213,7 @@ namespace tdsl { namespace net {
                     const auto read_amount =
                         client.read(dst_buf.data() + bytes_recvd, amount_demanded);
 
-                    TDSL_DEBUG_PRINTLN(
+                    TDSL_TRACE_PRINTLN(
                         "tdsl_netimpl_arduino::do_recv(...) -> read amount: %u, demanded:%u",
                         read_amount, amount_demanded);
 
@@ -226,7 +226,7 @@ namespace tdsl { namespace net {
                             static_cast<int>(errc::disconnected)); // error case
                     }
                     else if (read_amount < 0) {
-                        TDSL_DEBUG_PRINTLN(
+                        TDSL_TRACE_PRINTLN(
                             "tdsl_netimpl_arduino::do_recv(...) -> ret <0, no data avail, waiting");
                         // No data available, so wait for some time
                         delay(poll_interval);
@@ -253,7 +253,7 @@ namespace tdsl { namespace net {
 
             } while (!(bytes_recvd == transfer_exactly));
 
-            TDSL_DEBUG_PRINTLN("tdsl_netimpl_arduino::do_recv(...) -> received %u bytes",
+            TDSL_TRACE_PRINTLN("tdsl_netimpl_arduino::do_recv(...) -> received %u bytes",
                                bytes_recvd);
 
             TDSL_ASSERT(bytes_recvd == transfer_exactly);

--- a/src/tdslite-net/asio/src/tdsl_netimpl_asio.cxx
+++ b/src/tdslite-net/asio/src/tdsl_netimpl_asio.cxx
@@ -205,7 +205,7 @@ namespace tdsl { namespace net {
             if (transfer_exactly > rem_space) {
                 TDSL_DEBUG_PRINTLN(
                     "tdsl_netimpl_asio::do_recv(tdsl::uint32_t) -> error, not enough "
-                    "space in recv buffer (%u vs %ld)",
+                    "space in recv buffer (%u vs %zu)",
                     transfer_exactly, rem_space);
                 TDSL_ASSERT(0);
                 return network_io_result::unexpected(-2); // error case;

--- a/src/tdslite-net/asio/src/tdsl_netimpl_asio.cxx
+++ b/src/tdslite-net/asio/src/tdsl_netimpl_asio.cxx
@@ -168,7 +168,8 @@ namespace tdsl { namespace net {
 
             const auto bytes_written = asio::write(*as_socket(socket_handle), bufs, ec);
             if (not ec) {
-                TDSL_DEBUG_PRINT("tdsl_netimpl_asio::do_send(byte_view, byte_view) -> sent %zu "
+                TDSL_DEBUG_PRINT("tdsl_netimpl_asio::do_send(byte_view, byte_view) -> "
+                                 "sent " TDSL_SIZET_FORMAT_SPECIFIER " "
                                  "byte(s), ec %d (%s)\n",
                                  bytes_written, ec.value(), ec.what().c_str());
             }
@@ -185,9 +186,9 @@ namespace tdsl { namespace net {
                 } break;
             }
 
-            TDSL_DEBUG_PRINTLN(
-                "tdsl_netimpl_asio::do_send(byte_view, byte_view) -> exit, bytes written %zu",
-                bytes_written);
+            TDSL_DEBUG_PRINTLN("tdsl_netimpl_asio::do_send(byte_view, byte_view) -> exit, bytes "
+                               "written " TDSL_SIZET_FORMAT_SPECIFIER "",
+                               bytes_written);
             (void) bytes_written;
             return e_result::success;
         }
@@ -205,7 +206,7 @@ namespace tdsl { namespace net {
             if (transfer_exactly > rem_space) {
                 TDSL_DEBUG_PRINTLN(
                     "tdsl_netimpl_asio::do_recv(tdsl::uint32_t) -> error, not enough "
-                    "space in recv buffer (%u vs %zu)",
+                    "space in recv buffer (%u vs " TDSL_SIZET_FORMAT_SPECIFIER ")",
                     transfer_exactly, rem_space);
                 TDSL_ASSERT(0);
                 return network_io_result::unexpected(-2); // error case;
@@ -222,7 +223,9 @@ namespace tdsl { namespace net {
                 TDSL_ASSERT(adv_r);
                 (void) adv_r;
                 TDSL_DEBUG_PRINTLN(
-                    "tdsl_netimpl_asio::do_recv(...) -> read bytes(%zu), consumable bytes (%zu)",
+                    "tdsl_netimpl_asio::do_recv(...) -> read bytes(" TDSL_SIZET_FORMAT_SPECIFIER
+                    "), consumable "
+                    "bytes (" TDSL_SIZET_FORMAT_SPECIFIER ")",
                     *result, writer->inuse_span().size_bytes());
                 TDSL_ASSERT(*result == transfer_exactly);
             }
@@ -241,8 +244,10 @@ namespace tdsl { namespace net {
                                          asio::buffer(dst_buf.data(), dst_buf.size_bytes()),
                                          asio::transfer_exactly(transfer_amount), ec);
             if (not ec) {
-                TDSL_DEBUG_PRINTLN("tdsl_netimpl_asio::do_recv(...) success, read %zu bytes",
-                                   read_bytes);
+                TDSL_DEBUG_PRINTLN(
+                    "tdsl_netimpl_asio::do_recv(...) success, read " TDSL_SIZET_FORMAT_SPECIFIER
+                    " bytes",
+                    read_bytes);
                 return read_bytes;
             }
 

--- a/src/tdslite-net/base/network_io_base.hpp
+++ b/src/tdslite-net/base/network_io_base.hpp
@@ -259,7 +259,7 @@ namespace tdsl {
                     auto rbuf_reader = network_buffer.get_reader();
                     if (rbuf_reader->remaining_bytes()) {
                         TDSL_DEBUG_PRINTLN("Although the EOM is received, receive buffer still "
-                                           "contains %ld bytes of "
+                                           "contains %zu bytes of "
                                            "data which means packet handler failed to handle "
                                            "all the data in the "
                                            "message. Discarding the data.",

--- a/src/tdslite-net/base/network_io_base.hpp
+++ b/src/tdslite-net/base/network_io_base.hpp
@@ -192,10 +192,12 @@ namespace tdsl {
                     // network
 
                     if (packet_data_size > network_buffer.get_writer()->remaining_bytes()) {
-                        TDSL_DEBUG_PRINTLN(
-                            "Cannot fit complete message into network buffer %zu > %zu "
-                            "will try partial pull",
-                            packet_data_size, network_buffer.get_writer()->remaining_bytes());
+                        TDSL_DEBUG_PRINTLN("Cannot fit complete message into network "
+                                           "buffer " TDSL_SIZET_FORMAT_SPECIFIER
+                                           " > " TDSL_SIZET_FORMAT_SPECIFIER " "
+                                           "will try partial pull",
+                                           packet_data_size,
+                                           network_buffer.get_writer()->remaining_bytes());
                         do {
                             if (network_buffer.get_writer()->remaining_bytes() == 0) {
                                 TDSL_DEBUG_PRINTLN(
@@ -226,7 +228,9 @@ namespace tdsl {
                         if (not nmsg_rdr->has_bytes(packet_data_size)) {
                             TDSL_DEBUG_PRINTLN(
                                 "network_io_base::do_receive_tds_pdu(...) -> error, receive buffer "
-                                "does not contain expected amount of bytes (%zu < %zu) ",
+                                "does not contain expected amount of bytes "
+                                "(" TDSL_SIZET_FORMAT_SPECIFIER " < " TDSL_SIZET_FORMAT_SPECIFIER
+                                ") ",
                                 nmsg_rdr->remaining_bytes(), packet_data_size);
                             // this should not happen
                             TDSL_ASSERT_MSG(
@@ -259,7 +263,7 @@ namespace tdsl {
                     auto rbuf_reader = network_buffer.get_reader();
                     if (rbuf_reader->remaining_bytes()) {
                         TDSL_DEBUG_PRINTLN("Although the EOM is received, receive buffer still "
-                                           "contains %zu bytes of "
+                                           "contains " TDSL_SIZET_FORMAT_SPECIFIER " bytes of "
                                            "data which means packet handler failed to handle "
                                            "all the data in the "
                                            "message. Discarding the data.",

--- a/src/tdslite-net/base/network_io_base.hpp
+++ b/src/tdslite-net/base/network_io_base.hpp
@@ -174,6 +174,7 @@ namespace tdsl {
                     static constexpr auto k_max_length = 32767;
                     const auto length                  = thdr_rdr.read<tdsl::uint16_t>();
                     if (length < sizeof(detail::tds_header) || length > k_max_length) {
+                        TDSL_DEBUG_PRINTLN("invalid tds message length %u", length);
                         // invalid length
                         TDSL_ASSERT_MSG(0, "Invalid tds message length!");
                         return processed_tds_message_count;
@@ -237,10 +238,12 @@ namespace tdsl {
                         // TODO: check if downstream consumed the message
                         // TODO: Check if we got enough space to pull the next message
                         const auto needed_bytes = packet_data_cb(message_type, *nmsg_rdr);
+                        if (needed_bytes) {
+                            TDSL_DEBUG_PRINTLN("network_impl_base::do_receive_tds_pdu(...) -> "
+                                               "packet_data_cb needs `%d` more bytes",
+                                               needed_bytes);
+                        }
 
-                        TDSL_DEBUG_PRINTLN("network_impl_base::do_receive_tds_pdu(...) -> "
-                                           "packet_data_cb needs `%d` more bytes",
-                                           needed_bytes);
                         (void) needed_bytes;
                     }
 

--- a/src/tdslite/detail/tdsl_command_context.hpp
+++ b/src/tdslite/detail/tdsl_command_context.hpp
@@ -404,9 +404,9 @@ namespace tdsl { namespace detail {
             if (not rr.has_bytes(k_min_colmetadata_bytes)) {
                 result.status       = token_handler_status::not_enough_bytes;
                 result.needed_bytes = k_min_colmetadata_bytes - rr.remaining_bytes();
-                TDSL_DEBUG_PRINTLN(
-                    "received COLMETADATA token, not enough bytes need (at least) %d, have %zu",
-                    k_min_colmetadata_bytes, rr.remaining_bytes());
+                TDSL_DEBUG_PRINTLN("received COLMETADATA token, not enough bytes need (at least) "
+                                   "%d, have " TDSL_SIZET_FORMAT_SPECIFIER,
+                                   k_min_colmetadata_bytes, rr.remaining_bytes());
                 return result;
             }
 
@@ -497,9 +497,9 @@ namespace tdsl { namespace detail {
                     if (not rr.has_bytes(k_collation_info_size)) {
                         result.status       = token_handler_status::not_enough_bytes;
                         result.needed_bytes = k_collation_info_size - rr.remaining_bytes();
-                        TDSL_DEBUG_PRINTLN(
-                            "not enough bytes to read collation information, need %d, have %zu",
-                            k_collation_info_size, rr.remaining_bytes());
+                        TDSL_DEBUG_PRINTLN("not enough bytes to read collation information, need "
+                                           "%d, have " TDSL_SIZET_FORMAT_SPECIFIER "",
+                                           k_collation_info_size, rr.remaining_bytes());
                         return result;
                     }
                     // FIXME: Read this info into current_column
@@ -529,7 +529,8 @@ namespace tdsl { namespace detail {
                         }
                         result.status       = token_handler_status::not_enough_bytes;
                         result.needed_bytes = k_table_name_size_len - rr.remaining_bytes();
-                        TDSL_DEBUG_PRINTLN("not enough bytes to read table name, need %d, have %zu",
+                        TDSL_DEBUG_PRINTLN("not enough bytes to read table name, need %d, "
+                                           "have " TDSL_SIZET_FORMAT_SPECIFIER,
                                            tname_needed_bytes, rr.remaining_bytes());
                         return result;
                     } while (0);
@@ -541,7 +542,8 @@ namespace tdsl { namespace detail {
                 if (not rr.has_bytes((colname_len_in_bytes))) {
                     result.status       = token_handler_status::not_enough_bytes;
                     result.needed_bytes = colname_len_in_bytes - rr.remaining_bytes();
-                    TDSL_DEBUG_PRINTLN("not enough bytes to read column name, need %d, have %zu",
+                    TDSL_DEBUG_PRINTLN("not enough bytes to read column name, need %d, "
+                                       "have " TDSL_SIZET_FORMAT_SPECIFIER "",
                                        colname_len_in_bytes, rr.remaining_bytes());
                     return result;
                 }
@@ -561,8 +563,9 @@ namespace tdsl { namespace detail {
                 ++colindex;
             }
 
-            TDSL_DEBUG_PRINTLN("received COLMETADATA token -> column count [%zu]",
-                               qstate.colmd.columns.size());
+            TDSL_DEBUG_PRINTLN(
+                "received COLMETADATA token -> column count [" TDSL_SIZET_FORMAT_SPECIFIER "]",
+                qstate.colmd.columns.size());
             result.status       = token_handler_status::success;
             result.needed_bytes = 0;
             return result;
@@ -637,7 +640,8 @@ namespace tdsl { namespace detail {
                         }
 
                         TDSL_DEBUG_PRINTLN("handle_row_token() --> not enough bytes for reading "
-                                           "field textptr, %zu more bytes needed",
+                                           "field textptr, " TDSL_SIZET_FORMAT_SPECIFIER
+                                           " more bytes needed",
                                            textptr_need_bytes - rr.remaining_bytes());
                         result.status       = token_handler_status::not_enough_bytes;
                         result.needed_bytes = textptr_need_bytes - rr.remaining_bytes();
@@ -704,8 +708,8 @@ namespace tdsl { namespace detail {
                 }
 
                 if (not rr.has_bytes(field_length)) {
-                    TDSL_DEBUG_PRINTLN("handle_row_token() --> not enough bytes for reading field, "
-                                       "%zu more bytes needed",
+                    TDSL_DEBUG_PRINTLN("handle_row_token() --> not enough bytes for reading "
+                                       "field, " TDSL_SIZET_FORMAT_SPECIFIER " more bytes needed",
                                        field_length - rr.remaining_bytes());
                     result.status       = token_handler_status::not_enough_bytes;
                     result.needed_bytes = field_length - rr.remaining_bytes();

--- a/src/tdslite/detail/tdsl_command_context.hpp
+++ b/src/tdslite/detail/tdsl_command_context.hpp
@@ -498,7 +498,7 @@ namespace tdsl { namespace detail {
                         result.status       = token_handler_status::not_enough_bytes;
                         result.needed_bytes = k_collation_info_size - rr.remaining_bytes();
                         TDSL_DEBUG_PRINTLN(
-                            "not enough bytes to read collation information, need %d, have %ld",
+                            "not enough bytes to read collation information, need %d, have %zu",
                             k_collation_info_size, rr.remaining_bytes());
                         return result;
                     }
@@ -529,7 +529,7 @@ namespace tdsl { namespace detail {
                         }
                         result.status       = token_handler_status::not_enough_bytes;
                         result.needed_bytes = k_table_name_size_len - rr.remaining_bytes();
-                        TDSL_DEBUG_PRINTLN("not enough bytes to read table name, need %d, have %ld",
+                        TDSL_DEBUG_PRINTLN("not enough bytes to read table name, need %d, have %zu",
                                            tname_needed_bytes, rr.remaining_bytes());
                         return result;
                     } while (0);
@@ -541,7 +541,7 @@ namespace tdsl { namespace detail {
                 if (not rr.has_bytes((colname_len_in_bytes))) {
                     result.status       = token_handler_status::not_enough_bytes;
                     result.needed_bytes = colname_len_in_bytes - rr.remaining_bytes();
-                    TDSL_DEBUG_PRINTLN("not enough bytes to read column name, need %d, have %ld",
+                    TDSL_DEBUG_PRINTLN("not enough bytes to read column name, need %d, have %zu",
                                        colname_len_in_bytes, rr.remaining_bytes());
                     return result;
                 }
@@ -637,7 +637,7 @@ namespace tdsl { namespace detail {
                         }
 
                         TDSL_DEBUG_PRINTLN("handle_row_token() --> not enough bytes for reading "
-                                           "field textptr, %lu more bytes needed",
+                                           "field textptr, %zu more bytes needed",
                                            textptr_need_bytes - rr.remaining_bytes());
                         result.status       = token_handler_status::not_enough_bytes;
                         result.needed_bytes = textptr_need_bytes - rr.remaining_bytes();
@@ -705,7 +705,7 @@ namespace tdsl { namespace detail {
 
                 if (not rr.has_bytes(field_length)) {
                     TDSL_DEBUG_PRINTLN("handle_row_token() --> not enough bytes for reading field, "
-                                       "%lu more bytes needed",
+                                       "%zu more bytes needed",
                                        field_length - rr.remaining_bytes());
                     result.status       = token_handler_status::not_enough_bytes;
                     result.needed_bytes = field_length - rr.remaining_bytes();

--- a/src/tdslite/detail/tdsl_tds_context.hpp
+++ b/src/tdslite/detail/tdsl_tds_context.hpp
@@ -156,7 +156,8 @@ namespace tdsl { namespace detail {
                 } break;
                 default: {
                     TDSL_DEBUG_PRINTLN(
-                        "tds_context::handle_msg: unhandled (%zu) bytes of msg with type (%d)",
+                        "tds_context::handle_msg: unhandled (" TDSL_SIZET_FORMAT_SPECIFIER
+                        ") bytes of msg with type (%d)",
                         nmsg_rdr.remaining_bytes(), static_cast<int>(message_type));
                 } break;
             }

--- a/src/tdslite/util/tdsl_buffer_object.hpp
+++ b/src/tdslite/util/tdsl_buffer_object.hpp
@@ -57,7 +57,9 @@ namespace tdsl {
             inline ~progressive_binary_reader() noexcept {
                 writer.shift_left(reader.offset());
                 in_use_flag = {false};
-                TDSL_DEBUG_PRINTLN("netbuf: [consumed `%zu`, inuse `%zu`, free `%zu`]",
+                TDSL_DEBUG_PRINTLN("netbuf: [consumed `" TDSL_SIZET_FORMAT_SPECIFIER
+                                   "`, inuse `" TDSL_SIZET_FORMAT_SPECIFIER
+                                   "`, free `" TDSL_SIZET_FORMAT_SPECIFIER "`]",
                                    reader.offset(), reader.remaining_bytes(),
                                    writer.remaining_bytes());
             }

--- a/src/tdslite/util/tdsl_debug_print.hpp
+++ b/src/tdslite/util/tdsl_debug_print.hpp
@@ -53,4 +53,44 @@
 #endif
 #endif
 
+#ifdef TDSL_TRACE_PRINT_ENABLED
+#include <cstdio>
+#include <cwchar>
+#include <tdslite/util/tdsl_hex_dump.hpp>
+
+#define TDSL_TRACE_PRINT(...)          std::fprintf(stdout, __VA_ARGS__)
+#define TDSL_TRACE_PRINTLN(...)        std::fprintf(stdout, __VA_ARGS__), std::fprintf(stdout, "\n")
+#define TDSL_TRACE_HEXDUMP(ARR, SIZE)  tdsl::util::hexdump(ARR, SIZE)
+#define TDSL_TRACE_HEXPRINT(ARR, SIZE) tdsl::util::hexprint(ARR, SIZE)
+#define TDSL_TRACE_WPRINT(...)         std::wprintf(__VA_ARGS__)
+#define TDSL_TRACE_WPRINTLN(...)       std::wprintf(__VA_ARGS__), std::wprintf("\n")
+#define TDSL_TRACE_PRINT_U16_AS_MB(U16SPAN)                                                        \
+    for (unsigned int i = 0; i < U16SPAN.size(); i++) {                                            \
+        putchar(*reinterpret_cast<const char *>(U16SPAN.data() + i));                              \
+    }
+#else
+
+#ifndef TDSL_TRACE_PRINT
+#define TDSL_TRACE_PRINT(...)
+#endif
+#ifndef TDSL_TRACE_PRINTLN
+#define TDSL_TRACE_PRINTLN(...)
+#endif
+#ifndef TDSL_TRACE_HEXDUMP
+#define TDSL_TRACE_HEXDUMP(...)
+#endif
+#ifndef TDSL_TRACE_HEXPRINT
+#define TDSL_TRACE_HEXPRINT(ARR, SIZE)
+#endif
+#ifndef TDSL_TRACE_WPRINT
+#define TDSL_TRACE_WPRINT(...)
+#endif
+#ifndef TDSL_TRACE_WPRINTLN
+#define TDSL_TRACE_WPRINTLN(...)
+#endif
+#ifndef TDSL_TRACE_PRINT_U16_AS_MB
+#define TDSL_TRACE_PRINT_U16_AS_MB(U16SPAN)
+#endif
+#endif
+
 #endif

--- a/src/tdslite/util/tdsl_macrodef.hpp
+++ b/src/tdslite/util/tdsl_macrodef.hpp
@@ -16,6 +16,14 @@
 #include <tdslite/util/tdsl_type_traits.hpp>
 #include <assert.h>
 
+#if SIZE_MAX == 0xFFFF
+#define TDSL_SIZET_FORMAT_SPECIFIER "%u"
+#elif SIZE_MAX == 0xFFFFFFFF
+#define TDSL_SIZET_FORMAT_SPECIFIER "%u"
+#else
+#define TDSL_SIZET_FORMAT_SPECIFIER "%lu"
+#endif
+
 /**
  * Mark a line of code as unreachable. If code flow reaches
  * a line marked with TDSL_UNREACHABLE, the program will

--- a/tests/sketches/arduino/arduino.cpp
+++ b/tests/sketches/arduino/arduino.cpp
@@ -2,14 +2,14 @@
 // Sketch options
 
 #ifndef CI_BUILD
-#define SKETCH_ENABLE_WATCHDOG_TIMER
+// #define SKETCH_ENABLE_WATCHDOG_TIMER
 #define SKETCH_ENABLE_SERIAL_OUTPUT
 #endif
 
 //  #define SKETCH_ENABLE_TDSL_DEBUG_LOG
 //   #define SKETCH_USE_DHCP // Increases memory usage
-#define SKETCH_TDSL_NETBUF_SIZE 512
-#define SKETCH_TDSL_PACKET_SIZE 512
+#define SKETCH_TDSL_NETBUF_SIZE 4096
+#define SKETCH_TDSL_PACKET_SIZE 2048
 // tdslite options
 #define TDSL_DISABLE_DEFAULT_ALLOCATOR 1
 
@@ -141,7 +141,7 @@ void initTdsliteDriver() {
     tdsl::tdslite_malloc_free(my_malloc, my_free);
     tdsl::arduino_driver<EthernetClient>::progmem_connection_parameters params;
     // Server's hostname or IP address.
-    params.server_name = TDSL_PMEMSTR("192.168.1.22"); // WL
+    params.server_name = TDSL_PMEMSTR("192.168.1.27"); // WL
     // params.server_name = TDSL_PMEMSTR("192.168.1.45"); // WS
     //  SQL server port number
     params.port        = 14333;
@@ -182,7 +182,8 @@ inline void tdslite_loop() {
         const auto result =
             driver.execute_query(TDSL_PMEMSTR("SELECT * FROM #hello_world;"), row_callback);
         (void) result;
-        SERIAL_PRINTLNF(">> Report: row count [%d], free RAM [%d] <<", row_count, freeMemory());
+        SERIAL_PRINTLNF(">> Report: row count [%d], free RAM [%d] <<", result.affected_rows,
+                        freeMemory());
         SERIAL_PRINTLNF("%d", freeMemory());
     }
 }


### PR DESCRIPTION
some network implementations have a limitation for the amount of data can be pulled from the hw buffer in a single read() call which is not compatible with the pull-all strategy we were using.

the new implementation changes the way we pull the data from the client and now supports partial pulls as well.

also, removed localPort() usage from debug log calls.