### PR TITLE
tdsl_netimpl_*: refactor do_connect to use expected<>

### DIFF
--- a/src/tdslite-net/asio/include/tdslite-net/asio/tdsl_netimpl_asio.hpp
+++ b/src/tdslite-net/asio/include/tdslite-net/asio/tdsl_netimpl_asio.hpp
@@ -60,7 +60,8 @@ namespace tdsl { namespace net {
          * @returns -2 when asynchronous resolve operation of previous @ref do_connect call is still
          * in progress
          */
-        TDSL_SYMBOL_VISIBLE tdsl::int32_t do_connect(tdsl::char_view target, tdsl::uint16_t port);
+        TDSL_SYMBOL_VISIBLE tdsl::expected<tdsl::traits::true_type, int>
+        do_connect(tdsl::char_view target, tdsl::uint16_t port);
 
         // --------------------------------------------------------------------------------
 

--- a/src/tdslite-net/asio/src/tdsl_netimpl_asio.cxx
+++ b/src/tdslite-net/asio/src/tdsl_netimpl_asio.cxx
@@ -83,8 +83,8 @@ namespace tdsl { namespace net {
 
         // --------------------------------------------------------------------------------
 
-        tdsl::int32_t tdsl_netimpl_asio::do_connect(tdsl::span<const char> target,
-                                                    tdsl::uint16_t port) {
+        tdsl::expected<tdsl::traits::true_type, int>
+        tdsl_netimpl_asio::do_connect(tdsl::span<const char> target, tdsl::uint16_t port) {
 
             enum e_result : tdsl::int32_t
             {
@@ -97,7 +97,7 @@ namespace tdsl { namespace net {
             if (socket_handle) {
                 TDSL_DEBUG_PRINT(
                     "tdsl_netimpl_asio::do_connect(...) -> exit, socket already alive\n");
-                return e_result::socket_already_alive;
+                return tdsl::unexpected(static_cast<int>(e_result::socket_already_alive));
             }
 
             // Let's try to resolve the given address first.
@@ -132,7 +132,7 @@ namespace tdsl { namespace net {
                         socket_handle = std::move(sock);
                         // We're connected to one endpoint, stop trying
                         TDSL_DEBUG_PRINT("tdsl_netimpl_asio::do_connect(...) -> exit, connected\n");
-                        return e_result::connected;
+                        return tdsl::traits::true_type{};
                     }
                 }
 
@@ -141,11 +141,11 @@ namespace tdsl { namespace net {
             else {
                 // Otherwise, we got a resolve failure error in our hands.
                 TDSL_DEBUG_PRINT("tdsl_netimpl_asio::do_connect(...) -> exit, resolve failed!\n");
-                return e_result::resolve_failed;
+                return tdsl::unexpected(static_cast<int>(e_result::resolve_failed));
             }
 
             TDSL_DEBUG_PRINT("tdsl_netimpl_asio::do_connect(...) -> exit, connection failed\n");
-            return e_result::connection_failed;
+            return tdsl::unexpected(static_cast<int>(e_result::connection_failed));
         }
 
         // --------------------------------------------------------------------------------
@@ -209,7 +209,7 @@ namespace tdsl { namespace net {
                     "space in recv buffer (%u vs " TDSL_SIZET_FORMAT_SPECIFIER ")",
                     transfer_exactly, rem_space);
                 TDSL_ASSERT(0);
-                return network_io_result::unexpected(-2); // error case;
+                return tdsl::unexpected(-2); // error case;
             }
 
             // Retrieve the free space
@@ -258,7 +258,7 @@ namespace tdsl { namespace net {
                              ec.value(), ec.what().c_str());
 
             do_disconnect();
-            return network_io_result::unexpected(-1); // error case
+            return tdsl::unexpected(-1); // error case
         }
 
         // --------------------------------------------------------------------------------

--- a/src/tdslite-net/base/network_io_base.hpp
+++ b/src/tdslite-net/base/network_io_base.hpp
@@ -93,7 +93,8 @@ namespace tdsl {
              */
             template <typename T, traits::enable_when::same_any_of<T, string_view, wstring_view,
                                                                    progmem_string_view> = true>
-            TDSL_NODISCARD inline int connect(T host, tdsl::uint16_t port) noexcept {
+            TDSL_NODISCARD inline tdsl::expected<tdsl::traits::true_type, int>
+            connect(T host, tdsl::uint16_t port) noexcept {
                 return static_cast<Implementation &>(*this).do_connect(host, port);
             }
 

--- a/src/tdslite-net/base/network_io_contract.hpp
+++ b/src/tdslite-net/base/network_io_contract.hpp
@@ -27,7 +27,8 @@ namespace tdsl { namespace net {
      * A minimal network implementation is required to
      * implement the following functions:
      *
-     *    tdsl::int32_t do_connect(tdsl::char_view target, tdsl::uint16_t port);
+     *    tdsl::expected<tdsl::traits::true_type, int> do_connect(tdsl::char_view target,
+     *                                                            tdsl::uint16_t port);
      *    tdsl::int32_t do_disconnect() noexcept;
      *    tdsl::int32_t do_send(byte_view header, byte_view message) noexcept;
      *    expected<tdsl::uint32_t, tdsl::int32_t> do_recv(tdsl::uint32_t transfer_amount) noexcept;

--- a/src/tdslite/detail/tdsl_command_context.hpp
+++ b/src/tdslite/detail/tdsl_command_context.hpp
@@ -163,7 +163,7 @@ namespace tdsl { namespace detail {
          * The result set returned by query @p command can be read by providing
          * a row callback function
          *
-         * @returns execute_rpc_result::unexpected(e_rpc_error_code::invalid_mode) if @p mode
+         * @returns e_rpc_error_code::invalid_mode if @p mode
          *          value is invalid
          * @returns rows_affected if successful
          */
@@ -184,7 +184,7 @@ namespace tdsl { namespace detail {
                     TDSL_NOT_YET_IMPLEMENTED;
                     break;
                 default:
-                    return execute_rpc_result::unexpected(e_rpc_error_code::invalid_mode);
+                    return tdsl::unexpected(e_rpc_error_code::invalid_mode);
             }
 
             // 0xffff means we're going to use special procedure id

--- a/src/tdslite/detail/tdsl_driver.hpp
+++ b/src/tdslite/detail/tdsl_driver.hpp
@@ -126,7 +126,7 @@ namespace tdsl { namespace detail {
                 return pvr;
             }
 
-            if (not(0 == tds_ctx.connect(p.server_name, p.port))) {
+            if (not tds_ctx.connect(p.server_name, p.port)) {
                 return e_driver_error_code::connection_failed;
             }
 

--- a/src/tdslite/detail/tdsl_row.hpp
+++ b/src/tdslite/detail/tdsl_row.hpp
@@ -87,7 +87,7 @@ namespace tdsl {
             if (fields) {
                 return tdsl_row(fields, n_col);
             }
-            return make_result_t::unexpected(e_tdsl_row_make_err::MEM_ALLOC);
+            return tdsl::unexpected(e_tdsl_row_make_err::MEM_ALLOC);
         }
 
         // --------------------------------------------------------------------------------

--- a/tests/integration/it_tdsl_command_context.cpp
+++ b/tests/integration/it_tdsl_command_context.cpp
@@ -82,7 +82,7 @@ struct tds_command_ctx_it_fixture : public ::testing::Test {
     virtual void SetUp() override {
         login_ctx_t login{tds_ctx};
         const auto & params = mssql_2017_creds();
-        ASSERT_EQ(tds_ctx.do_connect(params.server_name, /*port=*/1433), 0);
+        ASSERT_EQ(tds_ctx.do_connect(params.server_name, /*port=*/1433), true);
         ASSERT_EQ(login.do_login(params), login_ctx_t::e_login_status::success);
         ASSERT_TRUE(tds_ctx.is_authenticated());
     }

--- a/tests/integration/it_tdsl_login_context.cpp
+++ b/tests/integration/it_tdsl_login_context.cpp
@@ -33,7 +33,7 @@ using tds_ctx_t = uut_t::tds_context_type;
 struct tds_login_ctx_it_fixture : public ::testing::Test {
 
     virtual void SetUp() override {
-        ASSERT_EQ(0, tds_ctx.do_connect("mssql-2017", /*port=*/1433));
+        ASSERT_EQ(true, tds_ctx.do_connect("mssql-2017", /*port=*/1433));
     }
 
     virtual void TearDown() override {}


### PR DESCRIPTION
do_connect function now returns a tdsl::expected<> object where the expected type is tds::traits::true_type and the error type is tdsl::int32_t. the caller now can perform a simple boolean check to see whether do_connect/connect succeeded or not.

also added tdsl::unexpected(...) function to make returning from unexpected return paths easier.

enhanced the existing ut_arduino_driver unit tests to cover do_connect and also chunked read scenario as well.

Closes: #17