### PR TITLE
tdsl_netimpl_arduino: replace explicit EthernetClientType move with forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ There are a few simple criterias before releasing the new version of the `tdslit
   - Arduino Mega
   - Arduino Nano
   - Arduino Uno
+  - Arduino Uno WiFi Rev. 2
+  - Arduino Portenta H7
 - [ESP sketch](tests/sketches/esp/esp.cpp)
   - NodeMCU-32 (ESP32S)
   - NodeMCU V3 (ESP8266MOD)

--- a/src/tdslite-net/arduino/tdsl_netimpl_arduino.hpp
+++ b/src/tdslite-net/arduino/tdsl_netimpl_arduino.hpp
@@ -58,10 +58,9 @@ namespace tdsl { namespace net {
          *
          * @param [in] network_io_buffer Network I/O buffer
          */
-        template <tdsl::uint32_t BufSize>
-        inline tdsl_netimpl_arduino(tdsl::uint8_t (&network_io_buffer) [BufSize],
-                                    EthernetClientType ec = {}) :
-            client(TDSL_MOVE(ec)) {
+        template <tdsl::uint32_t BufSize, typename... Args>
+        inline tdsl_netimpl_arduino(tdsl::uint8_t (&network_io_buffer) [BufSize], Args &&... args) :
+            client(TDSL_FORWARD(args)...) {
             this->network_buffer = tdsl::tdsl_buffer_object{network_io_buffer};
         }
 
@@ -72,9 +71,9 @@ namespace tdsl { namespace net {
          *
          * @param [in] network_io_buffer Network I/O buffer
          */
-        template <typename Z>
-        inline tdsl_netimpl_arduino(tdsl::byte_span network_io_buffer, EthernetClientType ec = {}) :
-            client(TDSL_MOVE(ec)) {
+        template <typename Z, typename... Args>
+        inline tdsl_netimpl_arduino(tdsl::byte_span network_io_buffer, Args &&... args) :
+            client(TDSL_FORWARD(args)...) {
             this->network_buffer = tdsl::tdsl_buffer_object{network_io_buffer};
         }
 


### PR DESCRIPTION
ArduinoCore-mbed's EthernetClient seems to crash when a default-constructed EthernetClient is moved or copied. tdsl_netimpl_arduino now forwards extra arguments to EthernetClient constructor to avoid this.